### PR TITLE
Add option to disable rounding on integer zoom levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ Some datatypes are assumed to be arrays: `ll` is `[lon, lat]`, `xy` and `px` are
 ```ruby
 # By default, precomputes up to z30
 mercator = SphericalMercator.new(size: 256)
+# Whether to round pixel values at integer zoom levels. Defaults to true.
+mercator = SphericalMercator.new(round: false)
 ```
 
 ### `px(lon_lat, zoom)`
 
 Convert lon, lat to screen pixel x, y from 0, 0 origin, at a certain zoom level.
 The inverse of `ll`
+
+Screen pixel values are rounded, unless the zoom level is a floating point value. To disable rounding on integer zoom levels, specify `round: false` when creating the SphericalMercator.
 
 ### `ll(px, zoom)`
 

--- a/lib/spherical_mercator.rb
+++ b/lib/spherical_mercator.rb
@@ -1,7 +1,10 @@
 require 'spherical_mercator/version'
 
 class SphericalMercator
+  
   attr_reader :options
+  attr_accessor :size, :round
+
   # Closures including constants and other precalculated values.
 
   EPSLN = 1.0e-10
@@ -11,7 +14,7 @@ class SphericalMercator
   A = 6_378_137.0
   MAX_EXTENT = 20_037_508.342_789_244
 
-  attr_accessor :size, :cache
+  attr_accessor :cache
 
   attr_accessor :ac, :bc, :cc, :zc
 
@@ -22,6 +25,8 @@ class SphericalMercator
     @options = opts || {}
 
     self.size = (options[:size] || 256).to_f
+    # Whether to round output values for integer zoom levels. Defaults to true.
+    self.round = (options[:round].nil?) ? true : options[:round]
 
     if cache[size].nil?
       size = self.size
@@ -60,7 +65,7 @@ class SphericalMercator
   # - `ll` {Array} `[lon, lat]` array of geographic coordinates.
   # - `zoom` {Number} zoom level.
   def px(lon_lat, zoom)
-    if float?(zoom)
+    if float?(zoom) || !self.round
       size = @size * (2**zoom)
       d = size / 2
       bc = (size / 360)

--- a/spec/spherical_mercator/spherical_mercator_spec.rb
+++ b/spec/spherical_mercator/spherical_mercator_spec.rb
@@ -18,6 +18,7 @@ end
 
 describe SphericalMercator do
   let!(:sm) { SphericalMercator.new }
+  let!(:sm_round) { SphericalMercator.new(round: false) }
 
   context '#bbox' do
     it '[0,0,0] converted to proper bbox' do
@@ -116,6 +117,10 @@ describe SphericalMercator do
 
     it 'PX with float zoom value converts' do
       expect(sm.px([-179, 85], 8.6574)).to eq([287.12734093961626, 169.30444219392666])
+    end
+  
+    it 'PX with forced rounding' do
+      expect(sm_round.px([-179, 85], 9)).to eq([364.0888888888876, 214.68476683766494])
     end
   end
 


### PR DESCRIPTION
Added new option `round`, specified when constructing the object, to specify pixel outputs should not be rounded, even on integer zoom levels.

Added this because I wanted floating pixel values for an integer zoom level, and specifying `9` as `9.0` did not work due to the custom float check.

If you have a different suggestion for implementing this functionality without a breaking change, feel free to comment.